### PR TITLE
Add listFiles as a new feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ Absolute camera file path.
 
 Returns `Promise`
 
+### listFiles(folderPath)
+List media files from a given folder.
+
+#### folderPath
+Required
+
+Type: `string`
+
+Absolute camera folder path.
+
+Returns `Promise`
+
 ## Configuration values
 You can check all config types and values in [constant.js](constant.js) and access it through `yi.config`.
 

--- a/client.js
+++ b/client.js
@@ -110,7 +110,15 @@ function sendMessage(message, testFunc, resolve) {
             var result = !!testFunc(data);
 
             if (result) {
-                resolve(data.hasOwnProperty('param') ? data.param : null);
+                if (data.hasOwnProperty('param')) {
+                    resolve(data.param);
+                }
+                else if (data.hasOwnProperty('listing')) {
+                    resolve(data.listing);
+                }
+                else {
+                    resolve(null);
+                }
             }
 
             return result;

--- a/constant.js
+++ b/constant.js
@@ -12,7 +12,8 @@ Constants.action = {
     GET_CONFIG:    3,
     SET_CONFIG:    2,
     START_STREAM:  259,
-    STOP_STREAM:   260
+    STOP_STREAM:   260,
+    LIST_FILES:    1282
 };
 
 Constants.config = {

--- a/yi-action-camera.js
+++ b/yi-action-camera.js
@@ -124,6 +124,16 @@ YiActionCamera.stopStream = function () {
     })
 };
 
+// List files from a folder
+YiActionCamera.listFiles = function (folderPath) {
+    return sendAction(constant.action.LIST_FILES, function (data) {
+        return (data.hasOwnProperty('rval') && data.hasOwnProperty('msg_id') && data.msg_id == constant.action.LIST_FILES);
+    }, folderPath)
+        .then(function (listing) {
+            return listing;
+        });
+}
+
 // Send action
 function sendAction(action, testFunc, param, type) {
     if (YiActionCamera.autoConnect && !client.isConnected()) {


### PR DESCRIPTION
This PR adds a new feature for listing all files from a given absolute path. 
This allows you to know how many files you have and when those files were created. 

The response looks like this: 
```
[ 
  { 'YDXJ0073.jpg': '2019-11-13 21:25:24' },
  { 'YDXJ0074.jpg': '2019-11-13 21:25:38' },
  { 'YDXJ0075.mp4': '2019-11-13 21:26:26' },
  { 'YDXJ0075_thm.mp4': '2019-11-13 21:26:26' },
  { 'YDXJ0075.THM': '2019-11-13 21:26:02' },
  { 'YDXJ0076.jpg': '2019-11-13 21:26:18' },
  { 'YDXJ0077.jpg': '2019-11-13 21:26:24' },
  { 'YDXJ0078.jpg': '2019-11-13 21:26:36' },
  { 'YDXJ0079.jpg': '2019-11-13 21:26:40' },
  { 'YDXJ0080.jpg': '2019-11-13 21:26:46' },
  { 'YDXJ0081.jpg': '2019-11-13 21:27:10' },
  { 'YDXJ0082.jpg': '2019-11-13 21:27:40' },
  { 'YDXJ0083.jpg': '2019-11-13 21:29:16' },
  { 'YDXJ0084.jpg': '2019-11-13 21:32:20' },
  { 'YDXJ0085.jpg': '2019-11-13 21:34:16' } 
]
```

Also, from this function, it will be easier to download all the files you want from a specific date.
Hope this PR will be merged :smile: 

PD: The action code for this feature was found [here](https://github.com/Informatic/ambarpc/blob/master/ambarpc.py) 